### PR TITLE
manual redirect to dashboard after ajax call added

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -209,6 +209,7 @@ $(document).ready(function() {
       method: "POST",
       data: data
     }).then(function() {
+      window.location.href = "/dashboard";
       console.log("Signed in");
     });
 


### PR DESCRIPTION
- AJAX overrides the redirect in our passport strategy, have to manually redirect to the dashboard page in the AJAX success/done body.